### PR TITLE
Return per-sample probability arrays in a new dataclass (with sample index)

### DIFF
--- a/spectral_metric/estimator.py
+++ b/spectral_metric/estimator.py
@@ -52,10 +52,11 @@ class CumulativeGradientEstimator(object):
             class_samples : class samples, ndarray (n_class, M, n_features)
         """
         # Compute E_{p(x\mid C_i)} [p(x\mid C_j)]
-        self.S, self.samples = compute_expectation_with_monte_carlo(
+        self.S, self.similarity_arrays = compute_expectation_with_monte_carlo(
             data,
             target,
             class_samples,
+            class_indices=self.class_indices,
             n_class=self.n_class,
             k_nearest=self.k_nearest,
             distance=self.distance,

--- a/spectral_metric/lib.py
+++ b/spectral_metric/lib.py
@@ -32,11 +32,13 @@ def compute_expectation_with_monte_carlo(
         class_samples: [n_class, M, n_features], the M samples per class
         class_indices: [n_class, indices], the indices of samples per class
         n_class: The number of classes
-        k_nearest: number of neighbors for k-NN
-        distance: Which distance to use
+        k_nearest: The number of neighbors for k-NN
+        distance: Which distance metric to use
 
-    Returns: [n_class, n_class] matrix with probabilities
-    #### CORRECT THIS
+    Returns:
+        expectation: [n_class, n_class], matrix with probabilities
+        similarity_arrays: [n_class, M, SimilarityArrays], dict of arrays with kNN class
+        proportions, raw and normalized by the Parzen-window, accessed via class and sample indices
 
     """
 

--- a/spectral_metric/types.py
+++ b/spectral_metric/types.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+import numpy as np
+
+Array = np.ndarray
+
+
+@dataclass
+class SimilarityArrays:
+    sample_probability: Array
+    sample_probability_norm: Array


### PR DESCRIPTION
Previously, `compute_expectation_with_monte_carlo()` returned `expectation` (S-matrix) and `samples` (per-sample arrays of Parzen-window-normalized kNN probabilities), but not (a) the non-normalized values or (b) the sample indices, which were available separately in `self.class_indices`.  

Now, `compute_expectation_with_monte_carlo()` returns `expectation` still, but the second object is a dictionary (keys are class indices) of dictionaries (keys are sample indices) of a new dataclass, `SimilarityArrays`, which includes both `sample_probability` (non-normalized kNN count array) and `sample_probability_norm` (Parzen-window-normalized kNN counts/probabilities).  

Thus, one can access normalized and non-normalized probability arrays, and they are associated with their sample ids.

I also changed some variable names and added some comments for easier code-reading.  Hope this is helpful and not annoying. :)  