### PR TITLE
Modify sampling structure to take into account misaligned classes

### DIFF
--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -15,6 +15,13 @@ def a_3_class_dataset():
     return x, y
 
 
+@pytest.fixture
+def a_3_class_dataset_with_wrong_indexing(a_3_class_dataset):
+    x, y = a_3_class_dataset
+    y[y == 2] = 3
+    return x, y
+
+
 @pytest.mark.parametrize('distance', ["euclidean", "cosine"])
 def test_estimator(a_3_class_dataset, distance):
     x, y = a_3_class_dataset
@@ -31,8 +38,8 @@ def test_estimator(a_3_class_dataset, distance):
         assert len(items) == 10
         for sample_id_key in items:
             assert isinstance(items[sample_id_key], SimilarityArrays)
-            assert(len(items[sample_id_key].sample_probability) ==
-                   len(items[sample_id_key].sample_probability_norm) == N_CLASS)
+            assert (len(items[sample_id_key].sample_probability) ==
+                    len(items[sample_id_key].sample_probability_norm) == N_CLASS)
             assert items[sample_id_key].sample_probability.sum() == 1
     for s_matrix_row in csg.S:
         assert s_matrix_row.sum() == pytest.approx(1, 1E-20)

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -43,3 +43,11 @@ def test_estimator(a_3_class_dataset, distance):
             assert items[sample_id_key].sample_probability.sum() == 1
     for s_matrix_row in csg.S:
         assert s_matrix_row.sum() == pytest.approx(1, 1E-20)
+
+
+def test_mismatched_labels(a_3_class_dataset_with_wrong_indexing):
+    x, y = a_3_class_dataset_with_wrong_indexing
+    csg = CumulativeGradientEstimator(M_sample=10, k_nearest=5)
+    csg.fit(x, y)
+    assert csg.evecs.shape == (N_CLASS + 1, N_CLASS + 1)
+    assert csg.evals == N_CLASS + 1


### PR DESCRIPTION
Fixes #14
Fixes #11
Fixes #9 


use a dict instead of list.
Also initialize with `np.eye` as we can assume that a class is overlapping with itself if it's not there.